### PR TITLE
feat(backend): Task model and protected CRUD API routes, resolves #5

### DIFF
--- a/backend/controllers/taskController.js
+++ b/backend/controllers/taskController.js
@@ -1,0 +1,88 @@
+import Task from '../models/Task.js';
+
+// @desc    Get all tasks
+// @route   GET /api/tasks
+// @access  Private (All authenticated users)
+export const getTasks = async (req, res, next) => {
+  try {
+    // Find all tasks, populate createdBy with name/email, and sort by deadline ascending
+    const tasks = await Task.find()
+      .populate('createdBy', 'name email')
+      .sort({ deadline: 1 });
+    res.json(tasks);
+  } catch (error) {
+    next(error);
+  }
+};
+
+// @desc    Get single task
+// @route   GET /api/tasks/:id
+// @access  Private
+export const getTask = async (req, res, next) => {
+  try {
+    const task = await Task.findById(req.params.id).populate('createdBy', 'name email');
+    if (!task) {
+      return res.status(404).json({ message: 'Task not found' });
+    }
+    res.json(task);
+  } catch (error) {
+    next(error);
+  }
+};
+
+// @desc    Create a new task
+// @route   POST /api/tasks
+// @access  Private/Admin
+export const createTask = async (req, res, next) => {
+  try {
+    const taskData = { ...req.body, createdBy: req.user.id };
+
+    // Only set notes if both fileName and downloadUrl exist in the request
+    if (taskData.notes && (!taskData.notes.fileName || !taskData.notes.downloadUrl)) {
+      delete taskData.notes;
+    }
+
+    const task = await Task.create(taskData);
+    res.status(201).json(task);
+  } catch (error) {
+    next(error);
+  }
+};
+
+// @desc    Update task
+// @route   PUT /api/tasks/:id
+// @access  Private/Admin
+export const updateTask = async (req, res, next) => {
+  try {
+    const task = await Task.findByIdAndUpdate(
+      req.params.id,
+      req.body,
+      { new: true, runValidators: true } // Returns the updated document and runs Schema validations
+    );
+
+    if (!task) {
+      return res.status(404).json({ message: 'Task not found' });
+    }
+
+    res.json(task);
+  } catch (error) {
+    next(error);
+  }
+};
+
+// @desc    Delete task
+// @route   DELETE /api/tasks/:id
+// @access  Private/Admin
+export const deleteTask = async (req, res, next) => {
+  try {
+    const task = await Task.findByIdAndDelete(req.params.id);
+    
+    if (!task) {
+      return res.status(404).json({ message: 'Task not found' });
+    }
+
+    res.json({ message: 'Task deleted successfully' });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/backend/models/Task.js
+++ b/backend/models/Task.js
@@ -1,0 +1,61 @@
+import mongoose from 'mongoose';
+
+const taskSchema = new mongoose.Schema({
+  taskName: {
+    type: String,
+    required: true,
+    trim: true
+  },
+  assignedTo: {
+    type: String,
+    required: true,
+    trim: true
+  },
+  startDateTime: {
+    type: Date,
+    required: true
+  },
+  deadline: {
+    type: Date,
+    required: true
+  },
+  endTime: {
+    type: Date,
+    default: null
+  },
+  priority: {
+    type: String,
+    enum: ['High', 'Medium', 'Low'],
+    required: true
+  },
+  status: {
+    type: String,
+    enum: ['Not Started', 'In Progress', 'Completed', 'Blocked'],
+    default: 'Not Started'
+  },
+  notes: {
+    fileName: String,
+    downloadUrl: String
+  },
+  createdBy: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+    required: true
+  }
+}, {
+  timestamps: true
+});
+
+// Transform output to expose virtual id, remove _id and __v
+taskSchema.set('toJSON', {
+  transform: (doc, ret) => {
+    ret.id = ret._id;
+    delete ret._id;
+    delete ret.__v;
+    return ret;
+  }
+});
+
+const Task = mongoose.model('Task', taskSchema);
+
+export default Task;

--- a/backend/routes/tasks.js
+++ b/backend/routes/tasks.js
@@ -1,0 +1,19 @@
+import express from 'express';
+import { getTasks, getTask, createTask, updateTask, deleteTask } from '../controllers/taskController.js';
+import { verifyToken, requireAdmin } from '../middleware/auth.js';
+
+const router = express.Router();
+
+// Apply verifyToken to ALL routes in this file (must be logged in to read or write)
+router.use(verifyToken);
+
+// GET routes (open to all authenticated users)
+router.get('/', getTasks);
+router.get('/:id', getTask);
+
+// POST/PUT/DELETE routes (restricted to admins only)
+router.post('/', requireAdmin, createTask);
+router.put('/:id', requireAdmin, updateTask);
+router.delete('/:id', requireAdmin, deleteTask);
+
+export default router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -3,6 +3,7 @@ import dotenv from 'dotenv';
 import cors from 'cors';
 import connectDB from './config/db.js';
 import authRoutes from './routes/auth.js';
+import taskRoutes from './routes/tasks.js';
 
 // Load environment variables from .env file
 dotenv.config();
@@ -23,7 +24,7 @@ app.get('/api/health', (req, res) => {
 
 // Routes
 app.use('/api/auth', authRoutes);
-// app.use('/api/tasks', taskRoutes);
+app.use('/api/tasks', taskRoutes);
 
 // Global Error Handler Middleware
 app.use((err, req, res, next) => {


### PR DESCRIPTION
Closes #5

## Overview
Implemented the [Task](cci:1://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/backend/controllers/taskController.js:17:0-30:2) Mongoose model and built the protected CRUD API endpoints with Role-Based Access Control (RBAC). Admin users have full read/write access, while standard authenticated users have read-only access.

## Changes Made
- **Task Model ([models/Task.js](cci:7://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/backend/models/Task.js:0:0-0:0)):** Engineered the schema with strict validations (enums for priority/status), automatic `status` defaulting, and an `ObjectId` reference (`createdBy`) linking to the `User` model.
- **Task Controllers ([controllers/taskController.js](cci:7://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/backend/controllers/taskController.js:0:0-0:0)):** Built 5 core CRUD operations ([getTasks](cci:1://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/backend/controllers/taskController.js:2:0-15:2), [getTask](cci:1://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/backend/controllers/taskController.js:17:0-30:2), [createTask](cci:1://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/backend/controllers/taskController.js:32:0-49:2), [updateTask](cci:1://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/backend/controllers/taskController.js:51:0-70:2), [deleteTask](cci:1://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/backend/controllers/taskController.js:72:0-87:2)). Included Mongoose `populate` logic to securely stitch user data into task queries.
- **Protected Routes ([routes/tasks.js](cci:7://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/backend/routes/tasks.js:0:0-0:0)):** Wired the controllers to `/api/tasks`. Applied [verifyToken](cci:1://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/backend/middleware/auth.js:3:0-33:2) middleware globally to block unauthorized access, and selectively applied the [requireAdmin](cci:1://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/backend/middleware/auth.js:35:0-42:2) middleware to all mutation routes (POST, PUT, DELETE).
- **Server Integration:** Mounted the new router in [server.js](cci:7://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/backend/server.js:0:0-0:0).

## Verification
- Automated tests passed successfully.
- Unauthenticated requests correctly return `401 Unauthorized`.
- Standard user attempts to mutate data correctly return `403 Forbidden`.
- Admin users can successfully create, edit, and delete tasks.
