### PR TITLE
feat(backend): Seed script to migrate db.json tasks to MongoDB, resolves #6

### DIFF
--- a/backend/seed.js
+++ b/backend/seed.js
@@ -1,0 +1,66 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import dotenv from 'dotenv';
+import mongoose from 'mongoose';
+import connectDB from './config/db.js';
+import Task from './models/Task.js';
+
+// Setup file paths for ES modules
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Load env vars
+dotenv.config();
+
+const seedDatabase = async () => {
+  try {
+    // 1. Connect to MongoDB
+    await connectDB();
+
+    // 2. Read local db.json
+    const dbJsonPath = path.join(__dirname, '../db.json');
+    const dbData = JSON.parse(fs.readFileSync(dbJsonPath, 'utf-8'));
+    const oldTasks = dbData.tasks || [];
+
+    // 3. Drop existing tasks (Idempotent action)
+    await Task.deleteMany({});
+    console.log('🗑️  Cleared existing tasks from MongoDB');
+
+    // 4. Map to new Schema
+    const newTasks = oldTasks.map(task => {
+      // Create a clean object mapping exactly what we need
+      const mappedTask = {
+        taskName: task.taskName,
+        assignedTo: task.assignedTo,
+        startDateTime: task.startDateTime,
+        deadline: task.deadline,
+        endTime: task.endTime || null,
+        priority: task.priority,
+        status: 'Not Started', // Forced to Not Started as per requirements
+        notes: task.notes && task.notes.fileName ? task.notes : undefined,
+      };
+
+      // Since the Schema has 'createdBy: { required: true }', storing null will throw a validation error.
+      // We are creating a dummy random ObjectId so the database accepts it without breaking the Schema rules,
+      // while technically keeping it orphaned/null from any real user.
+      mappedTask.createdBy = new mongoose.Types.ObjectId(); 
+
+      return mappedTask;
+    });
+
+    // 5. Insert mapped tasks
+    await Task.insertMany(newTasks);
+    
+    console.log(`✅ Success! Inserted ${newTasks.length} tasks into MongoDB.`);
+
+    // 6. Disconnect & Exit cleanly
+    mongoose.connection.close();
+    process.exit(0);
+  } catch (error) {
+    console.error('❌ Seeding failed:', error);
+    process.exit(1);
+  }
+};
+
+seedDatabase();


### PR DESCRIPTION
Closes #6

## Overview
Created a one-time database seed script ([backend/seed.js](cci:7://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/backend/seed.js:0:0-0:0)) to seamlessly migrate the existing 11 dummy tasks from the local [db.json](cci:7://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/db.json:0:0-0:0) file into the new MongoDB database without losing data.

## Changes Made
- **File System (fs):** Integrated Node's native `fs` module to dynamically read and parse the [db.json](cci:7://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/db.json:0:0-0:0) file located in the root directory.
- **Data Mapping:** Wrote mapping logic to translate the old JSON objects into our strict Mongoose schema format, specifically forcing the `status` to `"Not Started"` and dynamically generating an orphaned `ObjectId` for the `createdBy` field to satisfy schema validation rules.
- **Idempotency:** Utilized `Task.deleteMany({})` to ensure the script safely wipes out the existing collection before inserting, allowing it to be rerun safely without duplicating data.
- **Insertion:** Used `Task.insertMany()` for a highly efficient bulk data insert, logging the success result, and calling `process.exit(0)` for a clean exit.

## Verification
- Running `node seed.js` successfully inserts exactly 11 tasks.
- Re-running the script clears and re-inserts without duplication (idempotent).
- The script exits the terminal process cleanly upon completion.
