### PR TITLE
feat(frontend): Update Navbar with user profile and logout button, resolves #9

### DIFF
--- a/src/components/Navbar.css
+++ b/src/components/Navbar.css
@@ -215,3 +215,76 @@
   .search-wrapper { max-width: 100%; }
   .refresh-info span:last-child { display: none; }
 }
+
+/* User Profile & Auth Elements */
+.admin-link-btn {
+  background-color: rgba(88, 166, 255, 0.1);
+  color: #58a6ff;
+  border: 1px solid rgba(88, 166, 255, 0.4);
+  padding: 5px 14px;
+  border-radius: 20px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: all 0.2s;
+  white-space: nowrap;
+}
+
+.admin-link-btn:hover {
+  background-color: rgba(88, 166, 255, 0.2);
+  text-decoration: none;
+}
+
+.user-section {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding-left: 12px;
+  border-left: 1px solid var(--border);
+}
+
+.user-avatar {
+  background-color: var(--accent);
+  color: #0d1117;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 1rem;
+  flex-shrink: 0;
+}
+
+.user-name {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  font-weight: 500;
+  max-width: 120px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.logout-btn {
+  background: transparent;
+  color: #ff7b72;
+  border: 1px solid rgba(248, 81, 73, 0.4);
+  padding: 4px 10px;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.logout-btn:hover {
+  background-color: rgba(248, 81, 73, 0.1);
+}
+
+@media (max-width: 600px) {
+  .user-name {
+    display: none;
+  }
+}

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,6 +1,15 @@
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
 import './Navbar.css';
 
 function Navbar({ searchTerm, onSearchChange, priorityFilter, onPriorityChange, lastUpdated, taskCount }) {
+  const { user, logout } = useAuth();
+  const navigate = useNavigate();
+
+  const handleLogout = () => {
+    logout();
+    navigate('/login');
+  };
   const formattedTime = lastUpdated
     ? lastUpdated.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
     : 'Fetching...';
@@ -11,7 +20,7 @@ function Navbar({ searchTerm, onSearchChange, priorityFilter, onPriorityChange, 
         <div className="brand-icon">📋</div>
         <div className="brand-text">
           <h1>Task Dashboard</h1>
-          <span className="brand-subtitle">Read-Only View</span>
+          <span className="brand-subtitle">{user?.role === 'admin' ? 'Admin View' : 'Read-Only View'}</span>
         </div>
       </div>
 
@@ -54,6 +63,16 @@ function Navbar({ searchTerm, onSearchChange, priorityFilter, onPriorityChange, 
         <div className="refresh-info">
           <span className="pulse-dot"></span>
           <span>Updated {formattedTime}</span>
+        </div>
+
+        {user?.role === 'admin' && (
+          <a href="/admin/" className="admin-link-btn">Admin Panel</a>
+        )}
+
+        <div className="user-section">
+          <div className="user-avatar">{user?.name?.charAt(0)?.toUpperCase()}</div>
+          <span className="user-name">{user?.name}</span>
+          <button className="logout-btn" onClick={handleLogout}>Logout</button>
         </div>
       </div>
     </header>

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -82,14 +82,6 @@ function Dashboard() {
           <TaskTable tasks={processedTasks} />
         )}
       </main>
-      
-      {/* Temporary Logout Button to verify acceptance criteria */}
-      <button 
-        onClick={logout} 
-        style={{ position: 'fixed', bottom: '2rem', right: '2rem', padding: '12px 24px', background: '#ef4444', color: 'white', border: 'none', borderRadius: '8px', cursor: 'pointer', boxShadow: '0 4px 6px rgba(0,0,0,0.1)', fontWeight: 600, zIndex: 1000 }}
-      >
-        Sign Out
-      </button>
     </div>
   );
 }


### PR DESCRIPTION
Closes #9

## Overview
Transformed the top Navigation Bar into a fully dynamic component that displays the current user's profile, implements a secure logout flow, and conditionally displays access to the Admin Panel.

## Changes Made
- **Global Auth Integration:** Imported [useAuth](cci:1://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/src/contexts/AuthContext.jsx:4:0-4:53) into [Navbar.jsx](cci:7://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/src/components/Navbar.jsx:0:0-0:0) to dynamically subscribe the Navbar to the global user state.
- **Dynamic User Profile:**
  - Built a sleek, circular Avatar badge that programmatically extracts and capitalizes the first letter of the user's name (`user.name.charAt(0).toUpperCase()`).
  - Added the user's full name alongside the badge.
  - Implemented a secure [Logout](cci:1://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/src/components/Navbar.jsx:8:2-11:4) button that safely destroys the session token and physically steers the user back to the login page using the `useNavigate` React Router hook.
- **Role-Based Rendering:** 
  - The Navbar subtitle now dynamically reads "Admin View" or "Read-Only View" depending on `user.role`.
  - An "Admin Panel" link renders exclusively for authenticated administrators, linking them cleanly to the `admin/index.html` CRUD application.
- **Responsive CSS ([Navbar.css](cci:7://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/src/components/Navbar.css:0:0-0:0)):**
  - Styled the new User Profile section to seamlessly fit within the existing dark-themed glassmorphism layout.
  - Added a `@media (max-width: 600px)` breakpoint that cleanly hides the user's name text on mobile devices to prevent the header layout from crushing buttons together.
- **Cleanup:** Removed the temporary floating logout button from the bottom of [Dashboard.jsx](cci:7://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/src/pages/Dashboard.jsx:0:0-0:0).

## Verification
- Standard users see their initial, their name, and a "Read-Only View" subtitle.
- Standard users do **not** see the Admin Panel link.
- Admin users see the exact same profile layout, but with the "Admin View" subtitle and the blue Admin Panel link.
- Clicking the Logout button instantly clears the session and forces a redirect to `/login`.
- When squeezing the browser window to mobile width, the user name cleanly disappears to save space while keeping the avatar and buttons accessible. 
