### PR TITLE
feat(frontend): Display task status badge in TaskCard, resolves #10

### DIFF
--- a/src/components/TaskCard.css
+++ b/src/components/TaskCard.css
@@ -90,6 +90,45 @@
   50% { opacity: 0.6; }
 }
 
+/* Status Badges */
+.status-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 2px 8px;
+  border-radius: 20px;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.status-not-started {
+  color: #8b949e;
+  background: rgba(139, 148, 158, 0.1);
+  border: 1px solid rgba(139, 148, 158, 0.3);
+}
+
+.status-in-progress {
+  color: #58a6ff;
+  background: rgba(88, 166, 255, 0.1);
+  border: 1px solid rgba(88, 166, 255, 0.3);
+}
+
+.status-completed {
+  color: #3fb950;
+  background: rgba(63, 185, 80, 0.1);
+  border: 1px solid rgba(63, 185, 80, 0.3);
+}
+
+.status-blocked {
+  color: #ff7b72;
+  background: rgba(248, 81, 73, 0.1);
+  border: 1px solid rgba(248, 81, 73, 0.3);
+}
+
 .col-assigned {
   display: flex;
   align-items: center;

--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -6,6 +6,13 @@ const PRIORITY_CONFIG = {
   Low: { label: 'Low', className: 'priority-low', icon: '🟢' },
 };
 
+const STATUS_CONFIG = {
+  'Not Started': { className: 'status-not-started', icon: '⚪' },
+  'In Progress': { className: 'status-in-progress',  icon: '🔵' },
+  'Completed':   { className: 'status-completed',    icon: '🟢' },
+  'Blocked':     { className: 'status-blocked',      icon: '🔴' },
+};
+
 function formatDateTime(dateStr) {
   if (!dateStr) return '—';
   const d = new Date(dateStr);
@@ -33,6 +40,11 @@ function TaskCard({ task }) {
       <div className="col-name">
         <span className="task-name">{task.taskName}</span>
         {overdue && <span className="overdue-badge">Overdue</span>}
+        {task.status && (
+          <span className={`status-chip ${STATUS_CONFIG[task.status]?.className}`}>
+            {STATUS_CONFIG[task.status]?.icon} {task.status}
+          </span>
+        )}
       </div>
 
       <div className="col-assigned">


### PR DESCRIPTION
Closes #10

## Overview
Added a visually distinct "Pill Badge" to the [TaskCard](cci:1://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/src/components/TaskCard.jsx:29:0-93:1) component to dynamically render the current status of each task fetched from the backend API.

## Changes Made
- **Translation Map ([TaskCard.jsx](cci:7://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/src/components/TaskCard.jsx:0:0-0:0)):** Developed a `STATUS_CONFIG` dictionary to programmatically translate raw database status strings (`Not Started`, `In Progress`, `Completed`, `Blocked`) into specific CSS classes and matching emoji icons.
- **Conditional Rendering:** Safely injected the badge into the `.col-name` DOM structure directly below the task title and overdue badge, using `task.status && ...` to ensure gracefully handling of legacy tasks with null status fields.
- **Badge Styling ([TaskCard.css](cci:7://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/src/components/TaskCard.css:0:0-0:0)):** 
  - Utilized `inline-flex` for tight, responsive text wrapping.
  - Designed four distinct color themes matching the global dark UI:
    - `Not Started`: Subtle Grey (`#8b949e`)
    - `In Progress`: Accent Blue (`#58a6ff`)
    - `Completed`: Success Green (`#3fb950`)
    - `Blocked`: Warning Red (`#ff7b72`)

## Verification
- Verified the badges render flawlessly inside the task table grid constraints.
- Verified that all 11 default tasks (migrated during Issue #6) correctly display the Grey `⚪ Not Started` badge.
