### PR TITLE
feat(admin): Add JWT authentication to the admin panel, resolves #11

### DIFF
--- a/public/admin/admin.css
+++ b/public/admin/admin.css
@@ -80,6 +80,31 @@ body {
 }
 .view-dashboard-btn:hover { background: rgba(88,166,255,0.25); transform: translateY(-1px); }
 
+.admin-user-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-2);
+  margin-left: 8px;
+  padding-right: 12px;
+  border-right: 1px solid var(--border);
+}
+
+.logout-btn-admin {
+  background: transparent;
+  color: var(--high);
+  border: 1px solid var(--high-border);
+  padding: 6px 14px;
+  border-radius: var(--radius);
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: var(--transition);
+}
+
+.logout-btn-admin:hover {
+  background: var(--high-bg);
+}
+
 /* ── LAYOUT ─────────────────────────────────────────── */
 .layout {
   display: grid;

--- a/public/admin/admin.js
+++ b/public/admin/admin.js
@@ -1,4 +1,33 @@
-const API_URL = 'http://localhost:3001/tasks';
+const token = localStorage.getItem('authToken');
+if (!token) window.location.href = '/login';
+
+const userRaw = localStorage.getItem('authUser');
+const currentUser = userRaw ? JSON.parse(userRaw) : null;
+
+function getAuthHeaders() {
+  return {
+    'Content-Type': 'application/json',
+    'Authorization': `Bearer ${token}`,
+  };
+}
+
+function handleUnauthorized(status) {
+  if (status === 401 || status === 403) {
+    localStorage.removeItem('authToken');
+    localStorage.removeItem('authUser');
+    window.location.href = '/login';
+    return true;
+  }
+  return false;
+}
+
+function logout() {
+  localStorage.removeItem('authToken');
+  localStorage.removeItem('authUser');
+  window.location.href = '/login';
+}
+
+const API_URL = 'http://localhost:3001/api/tasks';
 let allTasks = [];
 let deleteTargetId = null;
 let nextId = null;
@@ -6,6 +35,9 @@ let nextId = null;
 // ─── Init ───────────────────────────────────────────────────────────────────
 
 async function init() {
+  if (currentUser) {
+    document.getElementById('adminUserName').textContent = currentUser.name;
+  }
   await fetchTasks();
   setInterval(fetchTasks, 10000);
 }
@@ -14,8 +46,11 @@ async function init() {
 
 async function fetchTasks() {
   try {
-    const res = await fetch(API_URL);
-    if (!res.ok) throw new Error('Server error');
+    const res = await fetch(API_URL, { headers: getAuthHeaders() });
+    if (!res.ok) {
+      if (handleUnauthorized(res.status)) return;
+      throw new Error('Server error');
+    }
     allTasks = await res.json();
     nextId = allTasks.length > 0 ? Math.max(...allTasks.map(t => t.id)) + 1 : 1;
     renderTasks();
@@ -28,26 +63,38 @@ async function fetchTasks() {
 async function createTask(data) {
   const res = await fetch(API_URL, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: getAuthHeaders(),
     body: JSON.stringify({ ...data, id: nextId }),
   });
-  if (!res.ok) throw new Error('Failed to create task');
+  if (!res.ok) {
+    if (handleUnauthorized(res.status)) return;
+    throw new Error('Failed to create task');
+  }
   return res.json();
 }
 
 async function updateTask(id, data) {
   const res = await fetch(`${API_URL}/${id}`, {
     method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
+    headers: getAuthHeaders(),
     body: JSON.stringify({ ...data, id }),
   });
-  if (!res.ok) throw new Error('Failed to update task');
+  if (!res.ok) {
+    if (handleUnauthorized(res.status)) return;
+    throw new Error('Failed to update task');
+  }
   return res.json();
 }
 
 async function deleteTask(id) {
-  const res = await fetch(`${API_URL}/${id}`, { method: 'DELETE' });
-  if (!res.ok) throw new Error('Failed to delete task');
+  const res = await fetch(`${API_URL}/${id}`, { 
+    method: 'DELETE',
+    headers: getAuthHeaders()
+  });
+  if (!res.ok) {
+    if (handleUnauthorized(res.status)) return;
+    throw new Error('Failed to delete task');
+  }
 }
 
 // ─── Form Handling ───────────────────────────────────────────────────────────

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -25,6 +25,8 @@
         <span class="status-dot" id="statusDot"></span>
         <span id="statusText">Connecting...</span>
       </span>
+      <span class="admin-user-label" id="adminUserName"></span>
+      <button class="logout-btn-admin" onclick="logout()">Logout</button>
       <a href="/" target="_blank" class="view-dashboard-btn">
         📋 View Dashboard
       </a>


### PR DESCRIPTION
Closes #11

## Overview
Secured the Vanilla JS Admin Panel by integrating JWT Authorization, preventing unauthenticated access and enabling secure CRUD operations against the live MongoDB API.

## Changes Made
- **API Target Update:** Re-routed the Vanilla JS `API_URL` to point to the secure Express API (`http://localhost:3001/api/tasks`) instead of the unsecured legacy `json-server`.
- **JWT Bouncer ([admin.js](cci:7://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/public/admin/admin.js:0:0-0:0)):** 
  - Implemented a pre-flight check that enforces the presence of an `authToken` in `localStorage` upon script initialization, violently bouncing unauthenticated users to `/login`.
  - Added a [getAuthHeaders()](cci:1://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/public/admin/admin.js:6:0-11:1) injector to dynamically append `Authorization: Bearer <token>` to all [fetch()](cci:1://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/public/admin/admin.js:46:0-60:1) (GET, POST, PUT, DELETE) requests.
  - Implemented a [handleUnauthorized](cci:1://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/public/admin/admin.js:13:0-21:1) middleware loop that catches `401`/`403` HTTP status codes, securely erases the stale `localStorage` tokens, and redirects the user to `/login` if their session expires mid-operation.
- **Dynamic User Header ([index.html](cci:7://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/public/admin/index.html:0:0-0:0) & [admin.css](cci:7://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/public/admin/admin.css:0:0-0:0)):**
  - Designed and injected a new Vanilla layout for the `.header-actions` section.
  - Parsed the `authUser` object from `localStorage` to programmatically display the active administrator's formatted name.
  - Added a responsive, stylized [Logout](cci:1://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/src/components/Navbar.jsx:8:2-11:4) button wired to a new Vanilla JS unmount/redirect sequence.

## Verification
- Attempting to visit `/admin/` directly via an unauthenticated session immediately triggers a redirect to `/login`.
- Logging in natively via an Admin account successfully authorizes and renders the restricted Admin Panel.
- Modifying or iterating tasks in the Admin Panel successfully transmits the Authorization headers, saving data permanently in MongoDB rather than throwing 401s.
- Clicking the Logout button completely shreds the VIP credentials and redirects user to Login securely.
