### PR TITLE
fix(admin): Remove leftover nextId json-server logic from admin panel resolves #22

### DIFF
--- a/public/admin/admin.js
+++ b/public/admin/admin.js
@@ -1,5 +1,5 @@
 const token = localStorage.getItem('authToken');
-if (!token) window.location.href = '/login';
+if (!token) window.location.href = '/';
 
 const userRaw = localStorage.getItem('authUser');
 const currentUser = userRaw ? JSON.parse(userRaw) : null;
@@ -15,7 +15,7 @@ function handleUnauthorized(status) {
   if (status === 401 || status === 403) {
     localStorage.removeItem('authToken');
     localStorage.removeItem('authUser');
-    window.location.href = '/login';
+    window.location.href = '/';
     return true;
   }
   return false;
@@ -24,13 +24,12 @@ function handleUnauthorized(status) {
 function logout() {
   localStorage.removeItem('authToken');
   localStorage.removeItem('authUser');
-  window.location.href = '/login';
+  window.location.href = '/';
 }
 
 const API_URL = 'http://localhost:3001/api/tasks';
 let allTasks = [];
 let deleteTargetId = null;
-let nextId = null;
 
 // ─── Init ───────────────────────────────────────────────────────────────────
 
@@ -52,7 +51,6 @@ async function fetchTasks() {
       throw new Error('Server error');
     }
     allTasks = await res.json();
-    nextId = allTasks.length > 0 ? Math.max(...allTasks.map(t => t.id)) + 1 : 1;
     renderTasks();
     setStatus(true);
   } catch (e) {
@@ -64,7 +62,7 @@ async function createTask(data) {
   const res = await fetch(API_URL, {
     method: 'POST',
     headers: getAuthHeaders(),
-    body: JSON.stringify({ ...data, id: nextId }),
+    body: JSON.stringify(data),
   });
   if (!res.ok) {
     if (handleUnauthorized(res.status)) return;


### PR DESCRIPTION
Closes #22

## Overview
Purged legacy `json-server` auto-increment logic from the Admin Panel that was causing broken `id: NaN` injections into the MongoDB payload. Also patched a critical Vite MPA-mode routing bug related to JWT expiration handling.

## Changes Made
- **Cleaned Task Creation ([admin.js](cci:7://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/public/admin/admin.js:0:0-0:0))**: Deleted the `let nextId` global variable and the `Math.max()` calculation block. Since MongoDB `_id` values are mathematically secured 24-character hexadecimal strings, JavaScript was evaluating them as `NaN` (Not a Number) and injecting `NaN` into the POST payload. 
- **Payload Security ([admin.js](cci:7://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/public/admin/admin.js:0:0-0:0))**: Simplified [createTask](cci:1://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/public/admin/admin.js:60:0-71:1) to send a pure `body: JSON.stringify(data)` payload without any frontend ID interference, natively delegating ID generation to MongoDB.
- **Fixed Redirect Bug ([admin.js](cci:7://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/public/admin/admin.js:0:0-0:0))**: Intercepted a bug where expired JWTs (`401 Unauthorized`) would trigger `window.location.href = '/login'`, which caused a harsh 404 Vite MPA failure. Rerouted the fallback to `window.location.href = '/'` to elegantly leverage React Router's internal `<ProtectedRoute>` interception architecture.

## Verification
- Verified the `NaN` injection is fully excised from the Network `POST` Request Payload.
- Verified that new Tasks flawlessly appear in the Admin Portal and Dashboard.
- Verified that expired `localStorage` tokens safely redirect unauthorized users back to the React Login page instead of throwing a blank 404 screen.
