### PR TITLE
fix(backend): Make createdBy optional in Task model, resolves #26

### DIFF
--- a/backend/models/Task.js
+++ b/backend/models/Task.js
@@ -40,7 +40,8 @@ const taskSchema = new mongoose.Schema({
   createdBy: {
     type: mongoose.Schema.Types.ObjectId,
     ref: 'User',
-    required: true
+    required: false,
+    default: null
   }
 }, {
   timestamps: true

--- a/backend/seed.js
+++ b/backend/seed.js
@@ -41,11 +41,9 @@ const seedDatabase = async () => {
         notes: task.notes && task.notes.fileName ? task.notes : undefined,
       };
 
-      // Since the Schema has 'createdBy: { required: true }', storing null will throw a validation error.
-      // We are creating a dummy random ObjectId so the database accepts it without breaking the Schema rules,
-      // while technically keeping it orphaned/null from any real user.
-      mappedTask.createdBy = new mongoose.Types.ObjectId(); 
-
+      // Legacy required: true hack removed. 
+      // createdBy is now legally optional in the Task Schema.
+      
       return mappedTask;
     });
 


### PR DESCRIPTION
Closes #26

## Overview
Eliminated a dangerous technical debt workaround inside the database loader. Relaxed the strict creation constraints on the fundamental [Task](cci:1://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/src/components/TaskCard.jsx:29:0-93:1) blueprint to natively support "system-owned" or legacy dummy tasks. 

## Changes Made
- **Schema Modification ([models/Task.js](cci:7://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/backend/models/Task.js:0:0-0:0))**: Altered the strict `createdBy` constraint. Changed `required: true` to `required: false` and implemented a logical `default: null` baseline fallback.
- **Hack Removal ([seed.js](cci:7://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/backend/seed.js:0:0-0:0))**: Since MongoDB now legally permits unowned tasks natively, I excised the hacky `new mongoose.Types.ObjectId()` constructor loop that was previously injecting randomly generated mathematical string gibberish to trick the database validation protocols. 

## Verification
- Explicitly validated that `npm run seed --prefix backend` cleanly flushes the database and successfully loads all dummy UI task configurations directly into the [Task](cci:1://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/src/components/TaskCard.jsx:29:0-93:1) collection without triggering `ValidatorError` crashes. 
- Verified that fully authenticated live application requests to `POST /api/tasks` continue to accurately append the `ref: 'User'` MongoDB ObjectId credential for real users while permitting `null` for legacy system seed properties.
