### PR TITLE
fix(frontend): Update stale API error message in Dashboard, resolves #27

### DIFF
--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -35,7 +35,7 @@ function Dashboard() {
         logout();
         return;
       }
-      setError('Unable to reach the task server. Please ensure the API server is running on port 3001.');
+      setError('Unable to load tasks. Please check your connection or contact your administrator.');
       console.error('Fetch error:', err);
     } finally {
       if (isInitial) setLoading(false);


### PR DESCRIPTION
Closes #27

## Overview
Replaced the stale, local-only error diagnostic message in the React Dashboard with a robust, generalized string suitable for production environments like Google App Engine.

## Changes Made
- **UI Error State ([Dashboard.jsx](cci:7://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/src/pages/Dashboard.jsx:0:0-0:0))**: Replaced the explicit port reference string (`'...running on port 3001.'`) with a generalized, user-facing connection fault fallback (`'Unable to load tasks. Please check your connection or contact your administrator.'`). 
- **Production Preparedness**: This prevents technical deployment details from bleeding into the client-side UI, which creates a highly unprofessional user experience when the application is natively hosted over HTTPS rather than local port bindings.

## Verification
- Explicitly disabled the Express backend locally and verified that the React Dashboard successfully caught the axios timeout and rendered the updated, polished text block within the red error banner.
