### PR TITLE
feat(backend): Filter tasks by assigned user with ?assignedTo query param, resolves #46

### DIFF
--- a/backend/controllers/taskController.js
+++ b/backend/controllers/taskController.js
@@ -5,8 +5,19 @@ import Task from '../models/Task.js';
 // @access  Private (All authenticated users)
 export const getTasks = async (req, res, next) => {
   try {
-    // Find all tasks, populate createdBy with name/email, and sort by deadline ascending
-    const tasks = await Task.find()
+    const filter = {};
+
+    // If ?assignedTo=me is passed, filter to only the logged-in user's tasks
+    if (req.query.assignedTo === 'me') {
+      filter.assignedTo = req.user.id;
+    } 
+    // If ?assignedTo=<userId> is passed (admin use), filter to that user
+    else if (req.query.assignedTo) {
+      filter.assignedTo = req.query.assignedTo;
+    }
+
+    // Find tasks, populate, and sort
+    const tasks = await Task.find(filter)
       .populate('assignedTo', 'name email')
       .populate('createdBy', 'name email')
       .sort({ deadline: 1 });

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -19,12 +19,16 @@ function Dashboard() {
   const [lastUpdated, setLastUpdated] = useState(null);
   const [searchTerm, setSearchTerm] = useState('');
   const [priorityFilter, setPriorityFilter] = useState('All');
-  const { token, logout } = useAuth(); 
+  const { token, user, logout } = useAuth();
 
   const fetchTasks = useCallback(async (isInitial = false) => {
     if (isInitial) setLoading(true);
     try {
-      const response = await axios.get(TASKS_API, {
+      const endpoint = user?.role === 'admin' 
+        ? TASKS_API 
+        : `${TASKS_API}?assignedTo=me`;
+
+      const response = await axios.get(endpoint, {
         headers: { Authorization: `Bearer ${token}` }
       });
       setTasks(response.data);
@@ -51,9 +55,10 @@ function Dashboard() {
   const processedTasks = tasks
     .filter((task) => {
       const term = searchTerm.toLowerCase();
+      const assignedName = task.assignedTo?.name ?? '';
       const matchesSearch =
         task.taskName.toLowerCase().includes(term) ||
-        task.assignedTo.toLowerCase().includes(term);
+        assignedName.toLowerCase().includes(term);
       const matchesPriority =
         priorityFilter === 'All' || task.priority === priorityFilter;
       return matchesSearch && matchesPriority;


### PR DESCRIPTION
## Overview
This PR resolves Issue #46 by allowing the frontend to filter the tasks returned by the API based on the assigned user. This ensures that non-admin dashboard users only see tasks assigned to them, while Admins continue to see all tasks.

## Changes Made
- **Backend API ([taskController.js](cci:7://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/backend/controllers/taskController.js:0:0-0:0))**: Updated [getTasks](cci:1://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/backend/controllers/taskController.js:2:0-27:2) to handle a new `?assignedTo=` query parameter.
  - Passing `?assignedTo=me` filters the MongoDB query using the authenticated user's ID (`req.user.id`).
  - Passing `?assignedTo=<id>` filters the MongoDB query by that specific user ID.
  - Omitting the parameter continues to return all tasks in the database.
- **Frontend App ([Dashboard.jsx](cci:7://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/src/pages/Dashboard.jsx:0:0-0:0))**: Updated [fetchTasks](cci:1://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/public/admin/admin.js:65:0-78:1) logic to be role-aware. 
  - If `user.role === 'admin'`, it fetches `/api/tasks` (gets everything).
  - If `user.role === 'user'`, it dynamically appends the query parameter to fetch `/api/tasks?assignedTo=me`.
- **Search Bar Stability Fix**: Patched a bug in [Dashboard.jsx](cci:7://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/src/pages/Dashboard.jsx:0:0-0:0)'s local search filter where running `.toLowerCase()` directly on the new `assignedTo` object would crash the app. It now safely extracts the embedded user's name before filtering.

## Acceptance Criteria Met
- [x] Admins continue to see all tasks (`/api/tasks`)
- [x] Regular users automatically only fetch their own tasks (`/api/tasks?assignedTo=me`)
- [x] Payload shape and sorting remain identical
