### PR TITLE
feat(fullstack): Role-based task visibility and UI updates, resolves #47

### DIFF
--- a/backend/controllers/taskController.js
+++ b/backend/controllers/taskController.js
@@ -7,13 +7,17 @@ export const getTasks = async (req, res, next) => {
   try {
     const filter = {};
 
-    // If ?assignedTo=me is passed, filter to only the logged-in user's tasks
-    if (req.query.assignedTo === 'me') {
+    if (req.user.role === 'admin') {
+      // Admins can optionally filter by user, or see everything
+      if (req.query.assignedTo) {
+        filter.assignedTo = req.query.assignedTo === 'me' 
+          ? req.user.id 
+          : req.query.assignedTo;
+      }
+      // No filter = all tasks
+    } else {
+      // Regular users ALWAYS only see their own tasks — non-negotiable
       filter.assignedTo = req.user.id;
-    } 
-    // If ?assignedTo=<userId> is passed (admin use), filter to that user
-    else if (req.query.assignedTo) {
-      filter.assignedTo = req.query.assignedTo;
     }
 
     // Find tasks, populate, and sort

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -20,7 +20,7 @@ function Navbar({ searchTerm, onSearchChange, priorityFilter, onPriorityChange, 
         <div className="brand-icon">📋</div>
         <div className="brand-text">
           <h1>Task Dashboard</h1>
-          <span className="brand-subtitle">{user?.role === 'admin' ? 'Admin View' : 'Read-Only View'}</span>
+          <span className="brand-subtitle">{user?.role === 'admin' ? 'Admin View' : 'My Tasks'}</span>
         </div>
       </div>
 

--- a/src/components/TaskTable.jsx
+++ b/src/components/TaskTable.jsx
@@ -1,13 +1,17 @@
 import TaskCard from './TaskCard';
 import './TaskTable.css';
 
-function TaskTable({ tasks }) {
+function TaskTable({ tasks, user }) {
   if (tasks.length === 0) {
+    const emptyMessage = user?.role === 'admin' 
+      ? 'No tasks match your filter criteria.' 
+      : 'You have no tasks assigned to you yet.';
+
     return (
       <div className="empty-state">
         <div className="empty-icon">🗂️</div>
         <h2>No Tasks Found</h2>
-        <p>Try adjusting your search or filter criteria.</p>
+        <p>{emptyMessage}</p>
       </div>
     );
   }

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -24,11 +24,7 @@ function Dashboard() {
   const fetchTasks = useCallback(async (isInitial = false) => {
     if (isInitial) setLoading(true);
     try {
-      const endpoint = user?.role === 'admin' 
-        ? TASKS_API 
-        : `${TASKS_API}?assignedTo=me`;
-
-      const response = await axios.get(endpoint, {
+      const response = await axios.get(TASKS_API, {
         headers: { Authorization: `Bearer ${token}` }
       });
       setTasks(response.data);
@@ -88,7 +84,7 @@ function Dashboard() {
             <p>{error}</p>
           </div>
         ) : (
-          <TaskTable tasks={processedTasks} />
+          <TaskTable tasks={processedTasks} user={user} />
         )}
       </main>
     </div>


### PR DESCRIPTION
## Overview
This PR resolves Issue #47 by enforcing strict Role-Based Access Control (RBAC) at the API level, rather than relying on frontend URL parameters.

## Changes Made
- **Backend API ([taskController.js](cci:7://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/backend/controllers/taskController.js:0:0-0:0))**: Updated [getTasks](cci:1://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/backend/controllers/taskController.js:2:0-31:2) to completely override the `assignedTo` query parameter for non-admin users. It forcefully injects `filter.assignedTo = req.user.id`, ensuring regular users can never view tasks that don't belong to them, even if requested directly via tools like Postman. Admins retain full visibility.
- **Frontend Dashboard ([Dashboard.jsx](cci:7://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/src/pages/Dashboard.jsx:0:0-0:0))**: Removed the `?assignedTo=me` query parameter since the backend now securely handles the routing logic automatically. Passed the `user` object down to child components.
- **Frontend UI ([Navbar.jsx](cci:7://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/src/components/Navbar.jsx:0:0-0:0) & [TaskTable.jsx](cci:7://file:///c:/Users/ajaya/OneDrive/Documents/Desktop/Task_dashboard/src/components/TaskTable.jsx:0:0-0:0))**: 
  - Changed the regular user's subtitle from "Read-Only View" to "My Tasks".
  - Updated the Empty State message conditionally: Admins see a filter-related empty state, while regular users see a message confirming they have zero assigned tasks.

## Acceptance Criteria Met
- [x] Backend automatically locks filter payload to the logged-in user if their role is 'user'.
- [x] Admins can continue viewing all tasks.
- [x] UI strings updated to provide context-aware feedback (e.g. Empty State array).
