### PR TITLE
feat(fullstack): Add Projects — group tasks under projects, resolves #50

### DIFF
--- a/backend/controllers/projectController.js
+++ b/backend/controllers/projectController.js
@@ -1,0 +1,81 @@
+import Project from '../models/Project.js';
+import Task from '../models/Task.js';
+
+// @desc    Get all projects
+// @route   GET /api/projects
+// @access  Private
+export const getProjects = async (req, res, next) => {
+  try {
+    const filter = {};
+    if (req.user.role !== 'admin') {
+      // Regular users only see projects they are members of (or we can let them see all active projects)
+      // Standard approach for tracking tools: users see all projects they can log time to.
+      // We will leave filter empty for now so they can see all projects to filter their tasks against it,
+      // or optionally restrict it. Let's restrict to members or no restriction depending on design.
+      // Easiest is to allow them to see all projects for filtering purposes.
+    }
+    const projects = await Project.find(filter).sort({ name: 1 });
+    res.json(projects);
+  } catch (error) {
+    next(error);
+  }
+};
+
+// @desc    Create a project
+// @route   POST /api/projects
+// @access  Private/Admin
+export const createProject = async (req, res, next) => {
+  try {
+    const project = await Project.create({
+      ...req.body,
+      createdBy: req.user.id
+    });
+    res.status(201).json(project);
+  } catch (error) {
+    next(error);
+  }
+};
+
+// @desc    Update project
+// @route   PUT /api/projects/:id
+// @access  Private/Admin
+export const updateProject = async (req, res, next) => {
+  try {
+    const project = await Project.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    if (!project) return res.status(404).json({ message: 'Project not found' });
+    res.json(project);
+  } catch (error) {
+    next(error);
+  }
+};
+
+// @desc    Delete project
+// @route   DELETE /api/projects/:id
+// @access  Private/Admin
+export const deleteProject = async (req, res, next) => {
+  try {
+    const project = await Project.findByIdAndDelete(req.params.id);
+    if (!project) return res.status(404).json({ message: 'Project not found' });
+    
+    // In production we might want to update tasks to null out the project reference
+    await Task.updateMany({ project: req.params.id }, { project: null });
+    
+    res.json({ message: 'Project deleted successfully' });
+  } catch (error) {
+    next(error);
+  }
+};
+
+// @desc    Get all tasks belonging to a specific project
+// @route   GET /api/projects/:id/tasks
+// @access  Private
+export const getProjectTasks = async (req, res, next) => {
+  try {
+    const tasks = await Task.find({ project: req.params.id })
+      .populate('assignedTo', 'name email')
+      .populate('createdBy', 'name email');
+    res.json(tasks);
+  } catch (error) {
+    next(error);
+  }
+};

--- a/backend/controllers/taskController.js
+++ b/backend/controllers/taskController.js
@@ -21,8 +21,13 @@ export const getTasks = async (req, res, next) => {
       filter.assignedTo = req.user.id;
     }
 
+    if (req.query.project) {
+      filter.project = req.query.project;
+    }
+
     // Find tasks, populate, and sort
     const tasks = await Task.find(filter)
+      .populate('project', 'name color')
       .populate('assignedTo', 'name email')
       .populate('createdBy', 'name email')
       .sort({ deadline: 1 });
@@ -48,6 +53,7 @@ export const getTasks = async (req, res, next) => {
 export const getTask = async (req, res, next) => {
   try {
     const task = await Task.findById(req.params.id)
+      .populate('project', 'name color')
       .populate('assignedTo', 'name email')
       .populate('createdBy', 'name email');
     if (!task) {

--- a/backend/models/Project.js
+++ b/backend/models/Project.js
@@ -1,0 +1,48 @@
+import mongoose from 'mongoose';
+
+const projectSchema = new mongoose.Schema({
+  name: {
+    type: String,
+    required: true,
+    trim: true
+  },
+  description: {
+    type: String,
+    default: ''
+  },
+  color: {
+    type: String,
+    default: '#6366f1' // default indigo color
+  },
+  billable: {
+    type: Boolean,
+    default: false
+  },
+  status: {
+    type: String,
+    enum: ['Active', 'Archived'],
+    default: 'Active'
+  },
+  createdBy: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User'
+  },
+  members: [{
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User'
+  }]
+}, {
+  timestamps: true
+});
+
+projectSchema.set('toJSON', {
+  transform: (doc, ret) => {
+    ret.id = ret._id;
+    delete ret._id;
+    delete ret.__v;
+    return ret;
+  }
+});
+
+const Project = mongoose.model('Project', projectSchema);
+export default Project;

--- a/backend/models/Task.js
+++ b/backend/models/Task.js
@@ -12,6 +12,11 @@ const taskSchema = new mongoose.Schema({
     required: false,
     default: null
   },
+  project: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Project',
+    default: null
+  },
   startDateTime: {
     type: Date,
     required: true

--- a/backend/routes/projects.js
+++ b/backend/routes/projects.js
@@ -1,0 +1,24 @@
+import express from 'express';
+import {
+  getProjects,
+  createProject,
+  updateProject,
+  deleteProject,
+  getProjectTasks
+} from '../controllers/projectController.js';
+import { verifyToken, requireAdmin } from '../middleware/auth.js';
+
+const router = express.Router();
+
+router.route('/')
+  .get(verifyToken, getProjects)
+  .post(verifyToken, requireAdmin, createProject);
+
+router.route('/:id')
+  .put(verifyToken, requireAdmin, updateProject)
+  .delete(verifyToken, requireAdmin, deleteProject);
+
+router.route('/:id/tasks')
+  .get(verifyToken, getProjectTasks);
+
+export default router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -8,6 +8,7 @@ import authRoutes from './routes/auth.js';
 import taskRoutes from './routes/tasks.js';
 import userRoutes from './routes/users.js';
 import timeEntryRoutes from './routes/timeEntries.js';
+import projectRoutes from './routes/projects.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -34,6 +35,7 @@ app.use('/api/auth', authRoutes);
 app.use('/api/tasks', taskRoutes);
 app.use('/api/users', userRoutes);
 app.use('/api/time-entries', timeEntryRoutes);
+app.use('/api/projects', projectRoutes);
 
 // Serve React production build
 app.use(express.static(path.join(__dirname, '../dist')));

--- a/public/admin/admin.js
+++ b/public/admin/admin.js
@@ -39,6 +39,7 @@ async function init() {
     document.getElementById('adminUserName').textContent = currentUser.name;
   }
   await fetchUsers();
+  await fetchProjects();
   await fetchTasks();
   setInterval(fetchTasks, 10000);
 }
@@ -60,6 +61,24 @@ async function fetchUsers() {
     });
   } catch (e) {
     console.warn('Could not load users for dropdown:', e.message);
+  }
+}
+
+async function fetchProjects() {
+  try {
+    const res = await fetch(`${API_BASE}/api/projects`, { headers: getAuthHeaders() });
+    if (!res.ok) return;
+    const projects = await res.json();
+    const select = document.getElementById('project');
+    select.innerHTML = '<option value="">-- No Project --</option>';
+    projects.forEach(p => {
+      const opt = document.createElement('option');
+      opt.value = p.id || p._id;
+      opt.textContent = p.name;
+      select.appendChild(opt);
+    });
+  } catch (e) {
+    console.warn('Could not load projects for dropdown:', e.message);
   }
 }
 
@@ -131,6 +150,7 @@ async function handleSubmit(e) {
   const data = {
     taskName: document.getElementById('taskName').value.trim(),
     assignedTo: document.getElementById('assignedTo').value || null,
+    project: document.getElementById('project').value || null,
     startDateTime: document.getElementById('startDateTime').value,
     deadline: document.getElementById('deadline').value,
     estimatedHours: document.getElementById('estimatedHours').value ? Number(document.getElementById('estimatedHours').value) : null,
@@ -171,6 +191,10 @@ function populateEditForm(task) {
   // Pre-select the correct user in the dropdown
   const assignedId = task.assignedTo?._id || task.assignedTo?.id || task.assignedTo || '';
   document.getElementById('assignedTo').value = assignedId;
+
+  const projectId = task.project?._id || task.project?.id || task.project || '';
+  document.getElementById('project').value = projectId;
+
   document.getElementById('startDateTime').value = toDatetimeLocal(task.startDateTime);
   document.getElementById('deadline').value = toDatetimeLocal(task.deadline);
   document.getElementById('estimatedHours').value = task.estimatedHours || '';

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -27,6 +27,9 @@
       </span>
       <span class="admin-user-label" id="adminUserName"></span>
       <button class="logout-btn-admin" onclick="logout()">Logout</button>
+      <a href="/admin/projects.html" class="view-dashboard-btn" style="background:var(--accent); color: #fff; border:none; margin-right: 10px;">
+        📁 Manage Projects
+      </a>
       <a href="/" target="_blank" class="view-dashboard-btn">
         📋 View Dashboard
       </a>
@@ -55,6 +58,13 @@
           <label for="assignedTo">Assigned To <span class="required">*</span></label>
           <select id="assignedTo">
             <option value="">-- Select Assignee --</option>
+          </select>
+        </div>
+
+        <div class="form-group">
+          <label for="project">Project / Group</label>
+          <select id="project">
+            <option value="">-- No Project --</option>
           </select>
         </div>
 

--- a/public/admin/projects.html
+++ b/public/admin/projects.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Manage Projects</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="admin.css" />
+  <style>
+    .color-preview { display: inline-block; width: 14px; height: 14px; border-radius: 50%; vertical-align: middle; margin-right: 8px; border: 1px solid rgba(255,255,255,0.2); }
+  </style>
+</head>
+<body>
+  <!-- HEADER -->
+  <header class="header">
+    <div class="header-brand">
+      <span class="brand-icon">📁</span>
+      <div>
+        <h1>Manage Projects</h1>
+        <span class="brand-badge" style="background: var(--accent)">Projects Data</span>
+      </div>
+    </div>
+    <div class="header-actions">
+      <a href="/admin/" class="view-dashboard-btn" style="margin-right: 10px; background: transparent; border: 1px solid var(--border); color: var(--text-primary);">
+        ⚙️ Manage Tasks
+      </a>
+      <a href="/" target="_blank" class="view-dashboard-btn">
+        📋 View Dashboard
+      </a>
+    </div>
+  </header>
+
+  <!-- MAIN -->
+  <div class="layout">
+    <aside class="form-panel">
+      <div class="panel-header">
+        <h2 id="formTitle">➕ Add New Project</h2>
+        <button class="cancel-btn hidden" id="cancelEditBtn" onclick="cancelEdit()">✕ Cancel</button>
+      </div>
+
+      <form id="projectForm" onsubmit="handleSubmit(event)">
+        <input type="hidden" id="projectId" />
+
+        <div class="form-group">
+          <label for="name">Project Name <span class="required">*</span></label>
+          <input type="text" id="name" placeholder="e.g. Website Redesign" required />
+        </div>
+
+        <div class="form-group">
+          <label for="color">Badge Color</label>
+          <input type="color" id="color" value="#6366f1" style="height: 40px; padding: 2px; width: 100%; cursor: pointer;" />
+        </div>
+
+        <div class="form-group">
+          <label for="status">Status</label>
+          <select id="status">
+            <option value="Active">Active</option>
+            <option value="Archived">Archived</option>
+          </select>
+        </div>
+
+        <div class="form-group">
+          <label for="description">Detailed Description</label>
+          <textarea id="description" placeholder="Project details, objectives, or scopes..." rows="4"></textarea>
+        </div>
+
+        <button type="submit" class="submit-btn" id="submitBtn">
+          <span>➕ Add Project</span>
+        </button>
+      </form>
+    </aside>
+
+    <main class="list-panel">
+      <div class="list-header">
+        <div class="list-title-row">
+          <h2>All Projects <span class="task-count-badge" id="projectCount">0</span></h2>
+        </div>
+      </div>
+      <div id="projectList" class="task-list"></div>
+    </main>
+  </div>
+
+  <div class="toast hidden" id="toast">
+    <span id="toastMessage"></span>
+  </div>
+
+  <script src="projects.js"></script>
+</body>
+</html>

--- a/public/admin/projects.js
+++ b/public/admin/projects.js
@@ -1,0 +1,137 @@
+const token = localStorage.getItem('authToken');
+if (!token) window.location.href = '/';
+
+function getAuthHeaders() {
+  return {
+    'Content-Type': 'application/json',
+    'Authorization': `Bearer ${token}`,
+  };
+}
+
+const API_BASE = window.location.origin;
+const API_URL = `${API_BASE}/api/projects`;
+let allProjects = [];
+
+async function init() {
+  await fetchProjects();
+}
+
+async function fetchProjects() {
+  try {
+    const res = await fetch(API_URL, { headers: getAuthHeaders() });
+    if (!res.ok) throw new Error('Failed to fetch');
+    allProjects = await res.json();
+    renderProjects();
+  } catch (e) {
+    showToast('Error loading projects', 'error');
+  }
+}
+
+async function handleSubmit(e) {
+  e.preventDefault();
+  const submitBtn = document.getElementById('submitBtn');
+  submitBtn.disabled = true;
+
+  const id = document.getElementById('projectId').value;
+  const data = {
+    name: document.getElementById('name').value.trim(),
+    color: document.getElementById('color').value,
+    status: document.getElementById('status').value,
+    description: document.getElementById('description').value.trim()
+  };
+
+  try {
+    if (id) {
+      await fetch(`${API_URL}/${id}`, { method: 'PUT', headers: getAuthHeaders(), body: JSON.stringify(data) });
+      showToast('Project updated!', 'success');
+    } else {
+      await fetch(API_URL, { method: 'POST', headers: getAuthHeaders(), body: JSON.stringify(data) });
+      showToast('Project created!', 'success');
+    }
+    resetForm();
+    await fetchProjects();
+  } catch (err) {
+    showToast('Error saving project', 'error');
+  } finally {
+    submitBtn.disabled = false;
+  }
+}
+
+function renderProjects() {
+  const list = document.getElementById('projectList');
+  document.getElementById('projectCount').textContent = allProjects.length;
+
+  if (allProjects.length === 0) {
+    list.innerHTML = `<div class="empty-state"><p>No projects found. Add one on the left!</p></div>`;
+    return;
+  }
+
+  list.innerHTML = allProjects.map(p => `
+    <div class="task-card">
+      <div class="task-card-header">
+        <h3 style="display:flex; align-items:center; margin: 0; font-size: 1.1rem; color: #fff;">
+          <span class="color-preview" style="background:${p.color}"></span> 
+          ${escapeHtml(p.name)}
+        </h3>
+        <div>
+          <button class="edit-btn" onclick="startEdit('${p.id || p._id}')">✏️ Edit</button>
+          <button class="delete-btn" onclick="deleteProj('${p.id || p._id}')">🗑️</button>
+        </div>
+      </div>
+      <div style="margin-top:10px; color:#c9d1d9; font-size:0.9rem">${escapeHtml(p.description) || '<i>No description provided.</i>'}</div>
+      <div style="margin-top:10px; font-size:0.8rem; display: inline-block; padding: 2px 8px; border-radius: 12px; background: rgba(255,255,255,0.1);">Status: ${p.status}</div>
+    </div>
+  `).join('');
+}
+
+function startEdit(id) {
+  const p = allProjects.find(x => String(x.id || x._id) === String(id));
+  if (!p) return;
+  
+  document.getElementById('formTitle').textContent = '✏️ Edit Project';
+  document.getElementById('cancelEditBtn').classList.remove('hidden');
+  document.getElementById('submitBtn').innerHTML = '<span>💾 Update</span>';
+  
+  document.getElementById('projectId').value = p.id || p._id;
+  document.getElementById('name').value = p.name;
+  document.getElementById('color').value = p.color;
+  document.getElementById('status').value = p.status;
+  document.getElementById('description').value = p.description;
+}
+
+function cancelEdit() { resetForm(); }
+
+function resetForm() {
+  document.getElementById('projectForm').reset();
+  document.getElementById('projectId').value = '';
+  document.getElementById('formTitle').textContent = '➕ Add New Project';
+  document.getElementById('cancelEditBtn').classList.add('hidden');
+  document.getElementById('submitBtn').innerHTML = '<span>➕ Add Project</span>';
+  document.getElementById('color').value = '#6366f1';
+}
+
+async function deleteProj(id) {
+  if (!confirm('Delete this project? Warning: Tasks assigned to this project will lose their project association.')) return;
+  try {
+    await fetch(`${API_URL}/${id}`, { method: 'DELETE', headers: getAuthHeaders() });
+    showToast('Deleted', 'success');
+    await fetchProjects();
+  } catch (e) {
+    showToast('Error', 'error');
+  }
+}
+
+function showToast(msg, type) {
+  const toast = document.getElementById('toast');
+  document.getElementById('toastMessage').textContent = msg;
+  toast.className = `toast ${type}`;
+  toast.classList.remove('hidden');
+  setTimeout(() => toast.classList.add('hidden'), 3500);
+}
+
+function escapeHtml(str) {
+  if (!str) return '';
+  return String(str).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');
+}
+
+init();

--- a/src/components/TaskCard.css
+++ b/src/components/TaskCard.css
@@ -243,6 +243,19 @@
   font-style: italic;
 }
 
+/* Project Badge Styles */
+.project-badge {
+  display: inline-block;
+  padding: 3px 10px;
+  border-radius: 12px;
+  font-size: 0.65rem;
+  font-weight: 600;
+  color: #fff;
+  text-shadow: 0 1px 2px rgba(0,0,0,0.6);
+  margin-bottom: 6px;
+  align-self: flex-start;
+}
+
 /* Progress Bar Styles */
 .estimate-bar-container {
   width: 100%;

--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -49,6 +49,11 @@ function TaskCard({ task }) {
       </div>
 
       <div className="col-name">
+        {task.project && (
+          <span className="project-badge" style={{ background: task.project.color }}>
+            {task.project.name}
+          </span>
+        )}
         <span className="task-name">{task.taskName}</span>
         
         {task.estimatedHours && (

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -19,12 +19,30 @@ function Dashboard() {
   const [lastUpdated, setLastUpdated] = useState(null);
   const [searchTerm, setSearchTerm] = useState('');
   const [priorityFilter, setPriorityFilter] = useState('All');
+  const [projects, setProjects] = useState([]);
+  const [projectFilter, setProjectFilter] = useState('all');
   const { token, user, logout } = useAuth();
+
+  const fetchProjects = useCallback(async () => {
+    try {
+      if (!token) return;
+      const res = await axios.get(`${API_BASE}/api/projects`, {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      setProjects(res.data);
+    } catch (err) {
+      console.error('Fetch projects error:', err);
+    }
+  }, [token]);
 
   const fetchTasks = useCallback(async (isInitial = false) => {
     if (isInitial) setLoading(true);
     try {
-      const response = await axios.get(TASKS_API, {
+      let url = TASKS_API;
+      if (projectFilter !== 'all') {
+        url += `?project=${projectFilter}`;
+      }
+      const response = await axios.get(url, {
         headers: { Authorization: `Bearer ${token}` }
       });
       setTasks(response.data);
@@ -40,13 +58,17 @@ function Dashboard() {
     } finally {
       if (isInitial) setLoading(false);
     }
-  }, [token]);
+  }, [token, projectFilter, logout]);
 
   useEffect(() => {
+    fetchProjects();
     fetchTasks(true);
-    const interval = setInterval(() => fetchTasks(false), POLL_INTERVAL);
+    const interval = setInterval(() => {
+      fetchProjects();
+      fetchTasks(false);
+    }, POLL_INTERVAL);
     return () => clearInterval(interval);
-  }, [fetchTasks]);
+  }, [fetchTasks, fetchProjects]);
 
   const processedTasks = tasks
     .filter((task) => {
@@ -84,7 +106,19 @@ function Dashboard() {
             <p>{error}</p>
           </div>
         ) : (
-          <TaskTable tasks={processedTasks} user={user} />
+          <>
+            <div className="project-filter-container" style={{ padding: '0 20px 10px', display: 'flex', justifyContent: 'flex-end' }}>
+              <select 
+                value={projectFilter} 
+                onChange={(e) => setProjectFilter(e.target.value)}
+                style={{ padding: '6px 12px', borderRadius: '6px', background: 'var(--bg-hover)', color: 'var(--text-primary)', border: '1px solid var(--border)' }}
+              >
+                <option value="all">All Projects</option>
+                {projects.map(p => <option key={p.id} value={p.id}>{p.name}</option>)}
+              </select>
+            </div>
+            <TaskTable tasks={processedTasks} user={user} />
+          </>
         )}
       </main>
     </div>


### PR DESCRIPTION
## Overview
This PR resolves Issue #50 by bringing a massive architectural grouping capability to the platform. Admins can now build, coordinate, and color-code `Projects` natively, allowing Normal Users to visually filter their individual task assignments based heavily around top-level application logic.

## Changes Made
- **Mongoose Modeling (`Project.js`)**: Designed a brand new master `Project` schema explicitly housing Name, hexadecimal UI coloring codes, extended Descriptions, and 'Active/Archived' operational statuses.
- **Dynamic Task Population (`Task.js`)**: Wired isolated Task documents natively into the Project schema via `ObjectId` references. Upgraded identical controller handlers inside `taskController.js` enforcing rigid `.populate('project', 'name color')` querying maps globally.
- **REST APIs (`projectController.js`)**: Built an impenetrable, JWT-safeguarded Express router (`/api/projects`) affording Admin endpoints for granular CRUD actions (Create, Update, Delete) and standard `verifyToken` visibility endpoints.
- **React Filtering Pipeline (`Dashboard.jsx`)**: Injected periodic lifecycle polling (`setInterval`) continuously mirroring background MongoDB data payloads. Bound resulting arrays gracefully atop TaskTable structures implementing native HTML `<select>` nodes explicitly updating API query params via `?project=`.
- **Admin UI Fabrication (`projects.js`)**: Constructed an entirely decoupled vanilla JS interface living silently at `/admin/projects.html`, permitting complete Admin CRUD over master categorical elements dynamically passing `Authorization: Bearer <TOKEN>` to network adapters.

## Acceptance Criteria Met
- [x] Admin can create, edit, and delete projects.
- [x] Tasks can be explicitly assigned to a project group natively via dropdowns.
- [x] Dashboard natively hosts a reactive `<select>` dynamically filtering states.
- [x] Each task card renders precise Project titles and accurate RGB thresholds in vibrant pills.
- [x] `GET /api/tasks?project=` explicitly restricts array outputs based precisely on database linkages.
