### PR TITLE
feat(frontend): Weekly timesheet view showing time logged per task per day, resolves #51

### DIFF
--- a/backend/check.js
+++ b/backend/check.js
@@ -1,0 +1,12 @@
+import dotenv from 'dotenv';
+dotenv.config();
+import connectDB from './config/db.js';
+import TimeEntry from './models/TimeEntry.js';
+
+const run = async () => {
+    await connectDB();
+    const entries = await TimeEntry.find().populate('task');
+    console.log(JSON.stringify(entries, null, 2));
+    process.exit(0);
+};
+run();

--- a/backend/controllers/timeController.js
+++ b/backend/controllers/timeController.js
@@ -54,17 +54,33 @@ export const stopTimer = async (req, res, next) => {
 // @access  Private
 export const getMyTimeEntries = async (req, res, next) => {
   try {
-    const filter = { user: req.user.id };
+    const filter = {};
+    
+    // Admin override support for Timesheet
+    if (req.user.role === 'admin' && req.query.user) {
+      filter.user = req.query.user === 'me' ? req.user.id : req.query.user;
+    } else {
+      filter.user = req.user.id;
+    }
+    
     if (req.query.taskId) filter.task = req.query.taskId;
 
     // Optional date range filtering could be added here
     if (req.query.from || req.query.to) {
         filter.startTime = {};
         if (req.query.from) filter.startTime.$gte = new Date(req.query.from);
-        if (req.query.to) filter.startTime.$lte = new Date(req.query.to);
+        // Include the entire end day
+        if (req.query.to) {
+          const toDate = new Date(req.query.to);
+          toDate.setHours(23, 59, 59, 999);
+          filter.startTime.$lte = toDate;
+        }
     }
 
-    const entries = await TimeEntry.find(filter).sort({ startTime: -1 });
+    const entries = await TimeEntry.find(filter)
+      .populate('task', 'taskName')
+      .sort({ startTime: -1 });
+      
     res.json(entries);
   } catch (error) {
     next(error);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import ProtectedRoute from './components/ProtectedRoute';
 import Login from './pages/Login';
 import Register from './pages/Register';
 import Dashboard from './pages/Dashboard';
+import Timesheet from './pages/Timesheet';
 import './App.css'; // Keep global CSS logic
 
 function App() {
@@ -16,6 +17,7 @@ function App() {
             <Route path="/login"    element={<Login />} />
             <Route path="/register" element={<Register />} />
             <Route path="/"         element={<ProtectedRoute><Dashboard /></ProtectedRoute>} />
+            <Route path="/timesheet" element={<ProtectedRoute><Timesheet /></ProtectedRoute>} />
             
             {/* Catch-all route gracefully redirects 404s back to Dashboard (which triggers auth checks) */}
             <Route path="*"         element={<Navigate to="/" replace />} />

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -25,34 +25,38 @@ function Navbar({ searchTerm, onSearchChange, priorityFilter, onPriorityChange, 
       </div>
 
       <div className="navbar-controls">
-        <div className="search-wrapper">
-          <span className="search-icon">🔍</span>
-          <input
-            type="text"
-            className="search-input"
-            placeholder="Search by task or person..."
-            value={searchTerm}
-            onChange={(e) => onSearchChange(e.target.value)}
-          />
-          {searchTerm && (
-            <button className="clear-btn" onClick={() => onSearchChange('')}>✕</button>
-          )}
-        </div>
+        {onSearchChange && (
+          <div className="search-wrapper">
+            <span className="search-icon">🔍</span>
+            <input
+              type="text"
+              className="search-input"
+              placeholder="Search by task or person..."
+              value={searchTerm}
+              onChange={(e) => onSearchChange(e.target.value)}
+            />
+            {searchTerm && (
+              <button className="clear-btn" onClick={() => onSearchChange('')}>✕</button>
+            )}
+          </div>
+        )}
 
-        <div className="filter-wrapper">
-          <label htmlFor="priority-filter" className="filter-label">Priority</label>
-          <select
-            id="priority-filter"
-            className="priority-select"
-            value={priorityFilter}
-            onChange={(e) => onPriorityChange(e.target.value)}
-          >
-            <option value="All">All</option>
-            <option value="High">🔴 High</option>
-            <option value="Medium">🟠 Medium</option>
-            <option value="Low">🟢 Low</option>
-          </select>
-        </div>
+        {onPriorityChange && (
+          <div className="filter-wrapper">
+            <label htmlFor="priority-filter" className="filter-label">Priority</label>
+            <select
+              id="priority-filter"
+              className="priority-select"
+              value={priorityFilter}
+              onChange={(e) => onPriorityChange(e.target.value)}
+            >
+              <option value="All">All</option>
+              <option value="High">🔴 High</option>
+              <option value="Medium">🟠 Medium</option>
+              <option value="Low">🟢 Low</option>
+            </select>
+          </div>
+        )}
       </div>
 
       <div className="navbar-meta">
@@ -61,12 +65,15 @@ function Navbar({ searchTerm, onSearchChange, priorityFilter, onPriorityChange, 
           <span>tasks</span>
         </div>
         <div className="refresh-info">
-          <span className="pulse-dot"></span>
-          <span>Updated {formattedTime}</span>
+          <span className="pulse-dot" style={{ display: lastUpdated ? 'inline-block' : 'none' }}></span>
+          <span>{lastUpdated ? `Updated ${formattedTime}` : 'Not Polling'}</span>
         </div>
 
+        <button className="admin-link-btn" onClick={() => navigate('/')} style={{ background: 'transparent' }}>📊 Dashboard</button>
+        <button className="admin-link-btn" onClick={() => navigate('/timesheet')} style={{ background: 'transparent', marginLeft: '10px' }}>🕒 Timesheet</button>
+
         {user?.role === 'admin' && (
-          <a href="/admin/" className="admin-link-btn">Admin Panel</a>
+          <a href="/admin/" className="admin-link-btn" style={{ marginLeft: '10px' }}>⚙️ Admin Panel</a>
         )}
 
         <div className="user-section">

--- a/src/pages/Timesheet.css
+++ b/src/pages/Timesheet.css
@@ -1,0 +1,128 @@
+/* src/pages/Timesheet.css */
+.timesheet-container {
+  padding: 0 24px 40px;
+  max-width: 1400px;
+  margin: 0 auto;
+  color: var(--text-primary);
+  animation: fadeIn 0.4s ease-out;
+}
+
+.timesheet-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 24px;
+  background: var(--bg-hover);
+  padding: 16px 24px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+}
+
+.week-nav {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.week-nav button {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  color: var(--text-primary);
+  padding: 8px 16px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.2s;
+  font-size: 0.9rem;
+}
+
+.week-nav button:hover {
+  background: var(--border);
+  color: #fff;
+}
+
+.week-nav span {
+  font-weight: 600;
+  font-size: 1.1rem;
+  min-width: 250px;
+  text-align: center;
+  color: var(--accent);
+}
+
+.user-switcher select {
+  padding: 8px 16px;
+  border-radius: 6px;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+  font-size: 0.9rem;
+  min-width: 200px;
+  cursor: pointer;
+}
+
+.timesheet-table-wrapper {
+  overflow-x: auto;
+  background: var(--bg-secondary);
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+}
+
+.timesheet-table {
+  width: 100%;
+  border-collapse: collapse;
+  text-align: right;
+}
+
+.timesheet-table th, .timesheet-table td {
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+}
+
+.timesheet-table th {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  background: var(--bg-hover);
+  letter-spacing: 0.5px;
+}
+
+.timesheet-table th.task-col, .timesheet-table td.task-col {
+  text-align: left;
+  width: 30%;
+  border-right: 1px solid var(--border);
+}
+
+.timesheet-table td.task-col {
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.timesheet-table tbody tr {
+  transition: background 0.2s;
+}
+
+.timesheet-table tbody tr:hover td {
+  background: rgba(255,255,255,0.02);
+}
+
+.empty-cell {
+  color: #4b5563; /* subtle muted dash */
+}
+
+.total-row {
+  background: rgba(99, 102, 241, 0.1);
+  font-weight: 700;
+}
+
+.total-row td {
+  color: var(--accent);
+  border-bottom: none;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
+}

--- a/src/pages/Timesheet.jsx
+++ b/src/pages/Timesheet.jsx
@@ -1,0 +1,213 @@
+import React, { useState, useEffect, useMemo } from 'react';
+import axios from 'axios';
+import { useAuth } from '../contexts/AuthContext';
+import Navbar from '../components/Navbar';
+import LoadingSpinner from '../components/LoadingSpinner';
+import './Timesheet.css';
+
+const API_BASE = import.meta.env.VITE_API_URL || '';
+
+// Date manipulation helpers
+const getMonday = (d) => {
+  const date = new Date(d);
+  const day = date.getDay(), diff = date.getDate() - day + (day === 0 ? -6 : 1);
+  return new Date(date.setDate(diff));
+};
+
+const getSunday = (monday) => {
+  const date = new Date(monday);
+  date.setDate(date.getDate() + 6);
+  date.setHours(23, 59, 59, 999);
+  return date;
+};
+
+const formatDate = (date) => {
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+};
+
+const formatISO = (date) => date.toISOString().split('T')[0];
+
+const formatDuration = (seconds) => {
+  if (!seconds || seconds === 0) return '—';
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  if (h === 0) return `${m}m`;
+  if (m === 0) return `${h}h`;
+  return `${h}h ${m}m`;
+};
+
+const DAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+
+export default function Timesheet() {
+  const { token, user } = useAuth();
+  
+  // State
+  const [currentDate, setCurrentDate] = useState(new Date());
+  const [entries, setEntries] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [users, setUsers] = useState([]);
+  const [selectedUser, setSelectedUser] = useState('me');
+
+  const monday = useMemo(() => getMonday(currentDate), [currentDate]);
+  const sunday = useMemo(() => getSunday(monday), [monday]);
+
+  useEffect(() => {
+    // If admin, fetch users for the dropdown
+    if (user?.role === 'admin') {
+      axios.get(`${API_BASE}/api/users`, { headers: { Authorization: `Bearer ${token}` } })
+        .then(res => setUsers(res.data))
+        .catch(err => console.error(err));
+    }
+  }, [user, token]);
+
+  useEffect(() => {
+    const fetchTimesheet = async () => {
+      setLoading(true);
+      try {
+        const url = `${API_BASE}/api/time-entries?from=${formatISO(monday)}&to=${formatISO(sunday)}&user=${selectedUser}`;
+        const res = await axios.get(url, {
+          headers: { Authorization: `Bearer ${token}` }
+        });
+        setEntries(res.data);
+      } catch (error) {
+        console.error('Failed to load timesheet', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+    if (token) fetchTimesheet();
+  }, [monday, sunday, selectedUser, token]);
+
+  const handlePrevWeek = () => {
+    const newDate = new Date(currentDate);
+    newDate.setDate(newDate.getDate() - 7);
+    setCurrentDate(newDate);
+  };
+
+  const handleNextWeek = () => {
+    const newDate = new Date(currentDate);
+    newDate.setDate(newDate.getDate() + 7);
+    setCurrentDate(newDate);
+  };
+
+  // Aggregation Engine
+  // 1. Group by Task ID
+  // 2. Within each task, array of 7 days
+  const aggregatedData = useMemo(() => {
+    const taskMap = {};
+    const dayTotals = [0, 0, 0, 0, 0, 0, 0];
+    let grandTotal = 0;
+
+    entries.forEach(entry => {
+      if (!entry.task) return; // Skip orphaned entries completely
+      const taskId = entry.task._id || entry.task;
+      const taskName = entry.task.taskName || 'Unknown Task';
+      
+      if (!taskMap[taskId]) {
+        taskMap[taskId] = { taskName, days: [0, 0, 0, 0, 0, 0, 0], totalRow: 0 };
+      }
+
+      // Determine day of week (0 = Monday, 6 = Sunday)
+      const entryDate = new Date(entry.startTime);
+      let dayIndex = entryDate.getDay() - 1;
+      if (dayIndex === -1) dayIndex = 6; // Sunday is 0 in JS Date, mapped safely to 6
+
+      // Ignore entries formally processed mathematically outside boundaries
+      if (entryDate >= monday && entryDate <= sunday) {
+        const dur = entry.duration || 0;
+        taskMap[taskId].days[dayIndex] += dur;
+        taskMap[taskId].totalRow += dur;
+        dayTotals[dayIndex] += dur;
+        grandTotal += dur;
+      }
+    });
+
+    return {
+      rows: Object.values(taskMap),
+      dayTotals,
+      grandTotal
+    };
+  }, [entries, monday, sunday]);
+
+  return (
+    <div className="app-wrapper">
+      <Navbar />
+      <main className="main-content" style={{ paddingTop: '20px' }}>
+        <div className="timesheet-container">
+          
+          <div className="timesheet-header">
+            <div className="week-nav">
+              <button onClick={handlePrevWeek}>&larr; Prev Week</button>
+              <span>{formatDate(monday)} &ndash; {formatDate(sunday)}</span>
+              <button onClick={handleNextWeek}>Next Week &rarr;</button>
+            </div>
+            
+            {user?.role === 'admin' && (
+              <div className="user-switcher">
+                <select value={selectedUser} onChange={e => setSelectedUser(e.target.value)}>
+                  <option value="me">My Timesheet</option>
+                  <optgroup label="Team Members">
+                    {users.map(u => (
+                      <option key={u.id} value={u.id}>{u.name}</option>
+                    ))}
+                  </optgroup>
+                </select>
+              </div>
+            )}
+          </div>
+
+          <div className="timesheet-table-wrapper">
+            <table className="timesheet-table">
+              <thead>
+                <tr>
+                  <th className="task-col">Task Name</th>
+                  {DAYS.map(d => <th key={d}>{d}</th>)}
+                  <th>Total</th>
+                </tr>
+              </thead>
+              <tbody>
+                {loading ? (
+                  <tr>
+                    <td colSpan={9} style={{ textAlign: 'center', padding: '80px' }}>
+                      <LoadingSpinner />
+                    </td>
+                  </tr>
+                ) : aggregatedData.rows.length === 0 ? (
+                  <tr>
+                    <td colSpan={9} style={{ textAlign: 'center', padding: '80px', color: 'var(--text-muted)' }}>
+                      No time logged this week. Head back to the Dashboard to blast some timers!
+                    </td>
+                  </tr>
+                ) : (
+                  <>
+                    {aggregatedData.rows.map((row, idx) => (
+                      <tr key={idx}>
+                        <td className="task-col">{row.taskName}</td>
+                        {row.days.map((seconds, i) => (
+                          <td key={i} className={seconds === 0 ? 'empty-cell' : ''}>
+                            {formatDuration(seconds)}
+                          </td>
+                        ))}
+                        <td style={{ fontWeight: 600, color: 'var(--accent)' }}>{formatDuration(row.totalRow)}</td>
+                      </tr>
+                    ))}
+                    <tr className="total-row">
+                      <td className="task-col">Weekly Total</td>
+                      {aggregatedData.dayTotals.map((seconds, i) => (
+                        <td key={i} className={seconds === 0 ? 'empty-cell' : ''}>
+                          {formatDuration(seconds)}
+                        </td>
+                      ))}
+                      <td>{formatDuration(aggregatedData.grandTotal)}</td>
+                    </tr>
+                  </>
+                )}
+              </tbody>
+            </table>
+          </div>
+
+        </div>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
This PR resolves Issue #51 by provisioning a fully integrated Weekly Timesheet module. Users can seamlessly access an aggregate Mon-Sun matrix of their time entries mathematically mapped against dynamically authenticated JWT payloads.

Changes Made
API Extensibility (

timeController.js
): Reprogrammed 

getMyTimeEntries
 to ingest explicit URL bounds (?from= and ?to=) restricting MongoDB $gte returns exclusively to requested week bounds. Installed role-based query overrides natively permitting Admins visibility across user pipelines.
Frontend Architecture (

Timesheet.jsx
): Designed an entirely new page rendering rigorous CSS table frameworks scaling seamlessly on wide matrices. Installed explicit JS date logic calculating structural week constraints iteratively shifting bounds across user inputs.
Mathematical Aggregator (useMemo): Designed an intensive array reducer flattening raw backend NoSQL documents into precise, task-centric objects holding length-7 integer groupings directly tracking structural week spans.
Router Hookups (

App.jsx
): Declared structural React routes rendering the newly mounted pages guarded inherently behind the <ProtectedRoute> validation wrapper.
Acceptance Criteria Met
 Matrix default natively bounds specifically around current week.
 'Previous/Next' week functionality manipulates boundaries fluently.
 Rows explicitly track independent tasks passing continuous sums into column metrics.
 Administrators successfully navigate alternative user timesheets natively.