### PR TITLE
feat(fullstack): Timesheet approval workflow, resolves #37

### DIFF
--- a/backend/controllers/timesheetController.js
+++ b/backend/controllers/timesheetController.js
@@ -1,0 +1,108 @@
+import WeeklyTimesheet from '../models/WeeklyTimesheet.js';
+
+// @desc    Submit a weekly timesheet for approval
+// @route   POST /api/timesheets/submit
+// @access  Private
+export const submitTimesheet = async (req, res, next) => {
+  try {
+    const { weekStart, weekEnd } = req.body;
+    if (!weekStart || !weekEnd) {
+      return res.status(400).json({ message: 'weekStart and weekEnd are required' });
+    }
+
+    const start = new Date(weekStart);
+    const end = new Date(weekEnd);
+
+    // Upsert: if already exists update status back to submitted (allow re-submission after rejection)
+    const timesheet = await WeeklyTimesheet.findOneAndUpdate(
+      { user: req.user.id, weekStart: start },
+      {
+        user: req.user.id,
+        weekStart: start,
+        weekEnd: end,
+        status: 'submitted',
+        adminNote: '',
+        submittedAt: new Date(),
+        reviewedAt: null,
+        reviewedBy: null
+      },
+      { upsert: true, new: true, runValidators: true }
+    );
+
+    res.status(201).json(timesheet);
+  } catch (error) {
+    next(error);
+  }
+};
+
+// @desc    Get timesheets (own for users; all for admins)
+// @route   GET /api/timesheets
+// @access  Private
+export const getTimesheets = async (req, res, next) => {
+  try {
+    const filter = {};
+    if (req.user.role !== 'admin') {
+      filter.user = req.user.id;
+    } else if (req.query.userId) {
+      filter.user = req.query.userId;
+    }
+
+    if (req.query.status) filter.status = req.query.status;
+
+    const timesheets = await WeeklyTimesheet.find(filter)
+      .populate('user', 'name email')
+      .populate('reviewedBy', 'name')
+      .sort({ weekStart: -1 });
+
+    res.json(timesheets);
+  } catch (error) {
+    next(error);
+  }
+};
+
+// @desc    Approve a timesheet
+// @route   PATCH /api/timesheets/:id/approve
+// @access  Private/Admin
+export const approveTimesheet = async (req, res, next) => {
+  try {
+    const timesheet = await WeeklyTimesheet.findById(req.params.id);
+    if (!timesheet) return res.status(404).json({ message: 'Timesheet not found' });
+    if (timesheet.status !== 'submitted') {
+      return res.status(400).json({ message: 'Only submitted timesheets can be approved' });
+    }
+
+    timesheet.status = 'approved';
+    timesheet.reviewedAt = new Date();
+    timesheet.reviewedBy = req.user.id;
+    timesheet.adminNote = '';
+    await timesheet.save();
+
+    res.json(timesheet);
+  } catch (error) {
+    next(error);
+  }
+};
+
+// @desc    Reject a timesheet
+// @route   PATCH /api/timesheets/:id/reject
+// @access  Private/Admin
+export const rejectTimesheet = async (req, res, next) => {
+  try {
+    const { adminNote } = req.body;
+    const timesheet = await WeeklyTimesheet.findById(req.params.id);
+    if (!timesheet) return res.status(404).json({ message: 'Timesheet not found' });
+    if (timesheet.status !== 'submitted') {
+      return res.status(400).json({ message: 'Only submitted timesheets can be rejected' });
+    }
+
+    timesheet.status = 'rejected';
+    timesheet.reviewedAt = new Date();
+    timesheet.reviewedBy = req.user.id;
+    timesheet.adminNote = adminNote || '';
+    await timesheet.save();
+
+    res.json(timesheet);
+  } catch (error) {
+    next(error);
+  }
+};

--- a/backend/models/WeeklyTimesheet.js
+++ b/backend/models/WeeklyTimesheet.js
@@ -1,0 +1,31 @@
+import mongoose from 'mongoose';
+
+const weeklyTimesheetSchema = new mongoose.Schema({
+  user: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  weekStart: { type: Date, required: true }, // Monday 00:00:00
+  weekEnd:   { type: Date, required: true }, // Sunday 23:59:59
+  status: {
+    type: String,
+    enum: ['draft', 'submitted', 'approved', 'rejected'],
+    default: 'submitted'
+  },
+  adminNote: { type: String, default: '' },
+  submittedAt: { type: Date, default: Date.now },
+  reviewedAt:  { type: Date, default: null },
+  reviewedBy:  { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null }
+}, { timestamps: true });
+
+// One submission per user per week
+weeklyTimesheetSchema.index({ user: 1, weekStart: 1 }, { unique: true });
+
+weeklyTimesheetSchema.set('toJSON', {
+  transform: (doc, ret) => {
+    ret.id = ret._id.toString();
+    delete ret._id;
+    delete ret.__v;
+  }
+});
+
+const WeeklyTimesheet = mongoose.model('WeeklyTimesheet', weeklyTimesheetSchema);
+
+export default WeeklyTimesheet;

--- a/backend/routes/timesheets.js
+++ b/backend/routes/timesheets.js
@@ -1,0 +1,19 @@
+import express from 'express';
+import { verifyToken, requireAdmin } from '../middleware/auth.js';
+import {
+  submitTimesheet,
+  getTimesheets,
+  approveTimesheet,
+  rejectTimesheet
+} from '../controllers/timesheetController.js';
+
+const router = express.Router();
+
+router.use(verifyToken);
+
+router.get('/', getTimesheets);
+router.post('/submit', submitTimesheet);
+router.patch('/:id/approve', requireAdmin, approveTimesheet);
+router.patch('/:id/reject', requireAdmin, rejectTimesheet);
+
+export default router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -10,6 +10,7 @@ import userRoutes from './routes/users.js';
 import timeEntryRoutes from './routes/timeEntries.js';
 import projectRoutes from './routes/projects.js';
 import reportRoutes from './routes/reports.js';
+import timesheetRoutes from './routes/timesheets.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -38,6 +39,7 @@ app.use('/api/users', userRoutes);
 app.use('/api/time-entries', timeEntryRoutes);
 app.use('/api/projects', projectRoutes);
 app.use('/api/reports', reportRoutes);
+app.use('/api/timesheets', timesheetRoutes);
 
 // Serve React production build
 app.use(express.static(path.join(__dirname, '../dist')));

--- a/src/pages/Timesheet.css
+++ b/src/pages/Timesheet.css
@@ -122,6 +122,139 @@
   border-bottom: none;
 }
 
+/* Approval workflow */
+.submission-status-badge {
+  padding: 6px 14px;
+  border-radius: 20px;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.submit-timesheet-btn {
+  padding: 8px 18px;
+  border-radius: 8px;
+  border: none;
+  background: var(--accent);
+  color: #fff;
+  font-weight: 600;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
+
+.submit-timesheet-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.submit-timesheet-btn:not(:disabled):hover {
+  opacity: 0.85;
+}
+
+.approval-queue {
+  margin-top: 32px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 24px;
+}
+
+.approval-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.approval-card {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: var(--bg-hover);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 16px 20px;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.approval-user {
+  font-weight: 600;
+  color: var(--text-primary);
+  font-size: 1rem;
+}
+
+.approval-week {
+  font-size: 0.9rem;
+  color: var(--accent);
+  margin-top: 4px;
+}
+
+.approval-submitted {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-top: 2px;
+}
+
+.approval-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.approve-btn {
+  padding: 7px 16px;
+  border-radius: 6px;
+  border: none;
+  background: rgba(16, 185, 129, 0.15);
+  color: #10b981;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.approve-btn:hover { background: rgba(16, 185, 129, 0.3); }
+
+.reject-btn {
+  padding: 7px 16px;
+  border-radius: 6px;
+  border: none;
+  background: rgba(239, 68, 68, 0.15);
+  color: #ef4444;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.reject-btn:hover { background: rgba(239, 68, 68, 0.3); }
+
+.cancel-btn {
+  padding: 7px 16px;
+  border-radius: 6px;
+  border: none;
+  background: var(--bg-secondary);
+  color: var(--text-muted);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.reject-form {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.reject-form input {
+  padding: 7px 12px;
+  border-radius: 6px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  color: var(--text-primary);
+  font-size: 0.85rem;
+  min-width: 200px;
+}
+
 @keyframes fadeIn {
   from { opacity: 0; transform: translateY(10px); }
   to { opacity: 1; transform: translateY(0); }

--- a/src/pages/Timesheet.jsx
+++ b/src/pages/Timesheet.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import axios from 'axios';
 import { useAuth } from '../contexts/AuthContext';
 import Navbar from '../components/Navbar';
@@ -38,45 +38,118 @@ const formatDuration = (seconds) => {
 
 const DAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 
+const STATUS_STYLES = {
+  submitted: { background: 'rgba(245, 158, 11, 0.15)', color: '#f59e0b', label: 'Pending Review' },
+  approved:  { background: 'rgba(16, 185, 129, 0.15)', color: '#10b981', label: 'Approved' },
+  rejected:  { background: 'rgba(239, 68, 68, 0.15)',  color: '#ef4444', label: 'Rejected' },
+};
+
 export default function Timesheet() {
   const { token, user } = useAuth();
-  
-  // State
+
   const [currentDate, setCurrentDate] = useState(new Date());
   const [entries, setEntries] = useState([]);
   const [loading, setLoading] = useState(true);
   const [users, setUsers] = useState([]);
   const [selectedUser, setSelectedUser] = useState('me');
 
+  // Approval workflow state
+  const [weekSubmission, setWeekSubmission] = useState(null); // current user's submission for this week
+  const [pendingSubmissions, setPendingSubmissions] = useState([]); // admin: all pending
+  const [submitLoading, setSubmitLoading] = useState(false);
+  const [rejectNote, setRejectNote] = useState('');
+  const [rejectingId, setRejectingId] = useState(null);
+
   const monday = useMemo(() => getMonday(currentDate), [currentDate]);
   const sunday = useMemo(() => getSunday(monday), [monday]);
 
+  const authHeader = { Authorization: `Bearer ${token}` };
+
   useEffect(() => {
-    // If admin, fetch users for the dropdown
     if (user?.role === 'admin') {
-      axios.get(`${API_BASE}/api/users`, { headers: { Authorization: `Bearer ${token}` } })
+      axios.get(`${API_BASE}/api/users`, { headers: authHeader })
         .then(res => setUsers(res.data))
         .catch(err => console.error(err));
     }
   }, [user, token]);
 
-  useEffect(() => {
-    const fetchTimesheet = async () => {
-      setLoading(true);
-      try {
-        const url = `${API_BASE}/api/time-entries?from=${formatISO(monday)}&to=${formatISO(sunday)}&user=${selectedUser}`;
-        const res = await axios.get(url, {
-          headers: { Authorization: `Bearer ${token}` }
-        });
-        setEntries(res.data);
-      } catch (error) {
-        console.error('Failed to load timesheet', error);
-      } finally {
-        setLoading(false);
-      }
-    };
-    if (token) fetchTimesheet();
+  const fetchTimesheet = useCallback(async () => {
+    setLoading(true);
+    try {
+      const url = `${API_BASE}/api/time-entries?from=${formatISO(monday)}&to=${formatISO(sunday)}&user=${selectedUser}`;
+      const res = await axios.get(url, { headers: authHeader });
+      setEntries(res.data);
+    } catch (error) {
+      console.error('Failed to load timesheet', error);
+    } finally {
+      setLoading(false);
+    }
   }, [monday, sunday, selectedUser, token]);
+
+  const fetchSubmissionStatus = useCallback(async () => {
+    try {
+      // Fetch current user's submission for this week
+      const res = await axios.get(`${API_BASE}/api/timesheets`, { headers: authHeader });
+      const weekStart = formatISO(monday);
+      const match = res.data.find(ts => formatISO(new Date(ts.weekStart)) === weekStart);
+      setWeekSubmission(match || null);
+    } catch (err) {
+      console.error('Failed to fetch submission status', err);
+    }
+  }, [monday, token]);
+
+  const fetchPendingSubmissions = useCallback(async () => {
+    if (user?.role !== 'admin') return;
+    try {
+      const res = await axios.get(`${API_BASE}/api/timesheets?status=submitted`, { headers: authHeader });
+      setPendingSubmissions(res.data);
+    } catch (err) {
+      console.error('Failed to fetch pending submissions', err);
+    }
+  }, [user, token]);
+
+  useEffect(() => {
+    if (token) {
+      fetchTimesheet();
+      fetchSubmissionStatus();
+      fetchPendingSubmissions();
+    }
+  }, [fetchTimesheet, fetchSubmissionStatus, fetchPendingSubmissions]);
+
+  const handleSubmit = async () => {
+    setSubmitLoading(true);
+    try {
+      await axios.post(`${API_BASE}/api/timesheets/submit`, {
+        weekStart: monday.toISOString(),
+        weekEnd: sunday.toISOString()
+      }, { headers: authHeader });
+      await fetchSubmissionStatus();
+    } catch (err) {
+      console.error('Submit failed', err);
+    } finally {
+      setSubmitLoading(false);
+    }
+  };
+
+  const handleApprove = async (id) => {
+    try {
+      await axios.patch(`${API_BASE}/api/timesheets/${id}/approve`, {}, { headers: authHeader });
+      await fetchPendingSubmissions();
+    } catch (err) {
+      console.error('Approve failed', err);
+    }
+  };
+
+  const handleReject = async (id) => {
+    try {
+      await axios.patch(`${API_BASE}/api/timesheets/${id}/reject`, { adminNote: rejectNote }, { headers: authHeader });
+      setRejectingId(null);
+      setRejectNote('');
+      await fetchPendingSubmissions();
+    } catch (err) {
+      console.error('Reject failed', err);
+    }
+  };
 
   const handlePrevWeek = () => {
     const newDate = new Date(currentDate);
@@ -90,29 +163,24 @@ export default function Timesheet() {
     setCurrentDate(newDate);
   };
 
-  // Aggregation Engine
-  // 1. Group by Task ID
-  // 2. Within each task, array of 7 days
   const aggregatedData = useMemo(() => {
     const taskMap = {};
     const dayTotals = [0, 0, 0, 0, 0, 0, 0];
     let grandTotal = 0;
 
     entries.forEach(entry => {
-      if (!entry.task) return; // Skip orphaned entries completely
+      if (!entry.task) return;
       const taskId = entry.task._id || entry.task;
       const taskName = entry.task.taskName || 'Unknown Task';
-      
+
       if (!taskMap[taskId]) {
         taskMap[taskId] = { taskName, days: [0, 0, 0, 0, 0, 0, 0], totalRow: 0 };
       }
 
-      // Determine day of week (0 = Monday, 6 = Sunday)
       const entryDate = new Date(entry.startTime);
       let dayIndex = entryDate.getDay() - 1;
-      if (dayIndex === -1) dayIndex = 6; // Sunday is 0 in JS Date, mapped safely to 6
+      if (dayIndex === -1) dayIndex = 6;
 
-      // Ignore entries formally processed mathematically outside boundaries
       if (entryDate >= monday && entryDate <= sunday) {
         const dur = entry.duration || 0;
         taskMap[taskId].days[dayIndex] += dur;
@@ -122,38 +190,63 @@ export default function Timesheet() {
       }
     });
 
-    return {
-      rows: Object.values(taskMap),
-      dayTotals,
-      grandTotal
-    };
+    return { rows: Object.values(taskMap), dayTotals, grandTotal };
   }, [entries, monday, sunday]);
+
+  const statusStyle = weekSubmission ? STATUS_STYLES[weekSubmission.status] : null;
 
   return (
     <div className="app-wrapper">
       <Navbar />
       <main className="main-content" style={{ paddingTop: '20px' }}>
         <div className="timesheet-container">
-          
+
           <div className="timesheet-header">
             <div className="week-nav">
               <button onClick={handlePrevWeek}>&larr; Prev Week</button>
               <span>{formatDate(monday)} &ndash; {formatDate(sunday)}</span>
               <button onClick={handleNextWeek}>Next Week &rarr;</button>
             </div>
-            
-            {user?.role === 'admin' && (
-              <div className="user-switcher">
-                <select value={selectedUser} onChange={e => setSelectedUser(e.target.value)}>
-                  <option value="me">My Timesheet</option>
-                  <optgroup label="Team Members">
-                    {users.map(u => (
-                      <option key={u.id} value={u.id}>{u.name}</option>
-                    ))}
-                  </optgroup>
-                </select>
-              </div>
-            )}
+
+            <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+              {user?.role === 'admin' && (
+                <div className="user-switcher">
+                  <select value={selectedUser} onChange={e => setSelectedUser(e.target.value)}>
+                    <option value="me">My Timesheet</option>
+                    <optgroup label="Team Members">
+                      {users.map(u => (
+                        <option key={u.id} value={u.id}>{u.name}</option>
+                      ))}
+                    </optgroup>
+                  </select>
+                </div>
+              )}
+
+              {/* Status badge */}
+              {statusStyle && (
+                <span className="submission-status-badge" style={{ background: statusStyle.background, color: statusStyle.color }}>
+                  {statusStyle.label}
+                  {weekSubmission.status === 'rejected' && weekSubmission.adminNote && (
+                    <span style={{ marginLeft: '6px', fontSize: '0.75rem' }}>— {weekSubmission.adminNote}</span>
+                  )}
+                </span>
+              )}
+
+              {/* Submit button — shown to non-admins or admins viewing their own sheet */}
+              {(user?.role !== 'admin' || selectedUser === 'me') && (
+                <button
+                  className="submit-timesheet-btn"
+                  onClick={handleSubmit}
+                  disabled={submitLoading || weekSubmission?.status === 'submitted' || weekSubmission?.status === 'approved'}
+                >
+                  {submitLoading ? 'Submitting…' :
+                    weekSubmission?.status === 'approved' ? 'Approved' :
+                    weekSubmission?.status === 'submitted' ? 'Submitted' :
+                    weekSubmission?.status === 'rejected' ? 'Resubmit' :
+                    'Submit for Approval'}
+                </button>
+              )}
+            </div>
           </div>
 
           <div className="timesheet-table-wrapper">
@@ -205,6 +298,50 @@ export default function Timesheet() {
               </tbody>
             </table>
           </div>
+
+          {/* Admin: Pending Approval Queue */}
+          {user?.role === 'admin' && pendingSubmissions.length > 0 && (
+            <div className="approval-queue">
+              <h3 style={{ color: 'var(--text-primary)', marginBottom: '16px' }}>
+                Pending Approvals ({pendingSubmissions.length})
+              </h3>
+              <div className="approval-list">
+                {pendingSubmissions.map(ts => (
+                  <div key={ts.id} className="approval-card">
+                    <div className="approval-info">
+                      <div className="approval-user">{ts.user?.name}</div>
+                      <div className="approval-week">
+                        {formatDate(new Date(ts.weekStart))} – {formatDate(new Date(ts.weekEnd))}
+                      </div>
+                      <div className="approval-submitted">
+                        Submitted {new Date(ts.submittedAt).toLocaleDateString()}
+                      </div>
+                    </div>
+
+                    <div className="approval-actions">
+                      <button className="approve-btn" onClick={() => handleApprove(ts.id)}>
+                        Approve
+                      </button>
+                      {rejectingId === ts.id ? (
+                        <div className="reject-form">
+                          <input
+                            type="text"
+                            placeholder="Rejection reason (optional)"
+                            value={rejectNote}
+                            onChange={e => setRejectNote(e.target.value)}
+                          />
+                          <button className="reject-btn" onClick={() => handleReject(ts.id)}>Confirm Reject</button>
+                          <button className="cancel-btn" onClick={() => { setRejectingId(null); setRejectNote(''); }}>Cancel</button>
+                        </div>
+                      ) : (
+                        <button className="reject-btn" onClick={() => setRejectingId(ts.id)}>Reject</button>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
 
         </div>
       </main>


### PR DESCRIPTION
- Add WeeklyTimesheet model with status (submitted/approved/rejected), adminNote, reviewedBy
- Add timesheetController: submit (upsert), approve, reject endpoints
- Add /api/timesheets routes with requireAdmin guard on approve/reject
- Register timesheets route in server.js
- Update Timesheet page: Submit for Approval button + status badge per week
- Admin pending approval queue below timesheet table with approve/reject + optional rejection note
- Re-submission allowed after rejection